### PR TITLE
fix the pdf font issue

### DIFF
--- a/job_template_blsa_seeley.txt
+++ b/job_template_blsa_seeley.txt
@@ -113,7 +113,7 @@ mkdir -p $DSTDIR/PDF
 RESDIR=${DSTDIR%/*}
 TEXTFILE=$RESDIR/DISKQ/OUTLOG/$(cut -d'/' -f5 <<<"$DSTDIR").txt
 PDFFILE=$DSTDIR/PDF/$(cut -d'/' -f5 <<<"$DSTDIR").pdf
-python -c 'from fpdf import FPDF; pdf = FPDF(); pdf.add_page(); pdf.set_font("Courier", size = 9);
+python -c 'from fpdf import FPDF; pdf = FPDF(); pdf.add_page(); pdf.set_font("courier", size = 9);
 f = open("'$TEXTFILE'", "r",encoding="latin-1");
 for line in f:
 	x = line.encode("latin1","ignore").decode("latin1")


### PR DESCRIPTION
There is only one place got changed. 

pdf.set_font("Courier", size = 9) -> pdf.set_font("courier", size = 9)

When I testing on my local account, there is no issue, while for the vuiis_archive_singularity account, it has to be the lower case of 'courier'. 