### PR TITLE
fix slurm node constraint syntax

### DIFF
--- a/job_template_blsa_seeley.txt
+++ b/job_template_blsa_seeley.txt
@@ -7,7 +7,7 @@
 #SBATCH --time=${job_walltime}
 #SBATCH --mem=${job_memory}mb
 #SBATCH -o ${job_output_file}
-#SBATCH --constraint=westmere,sandybridge,haswell,skylake
+#SBATCH --constraint=westmere|sandybridge|haswell|skylake
 
 echo "Starting smemwatch"
 smemwatch -k 95 -d 50 $$$$ &

--- a/job_template_fmriprep.txt
+++ b/job_template_fmriprep.txt
@@ -7,7 +7,7 @@
 #SBATCH --time=${job_walltime}
 #SBATCH --mem=${job_memory}mb
 #SBATCH -o ${job_output_file}
-#SBATCH --constraint=westmere,sandybridge,haswell,skylake
+#SBATCH --constraint=westmere|sandybridge|haswell|skylake
 
 echo "Starting smemwatch"
 smemwatch -k 95 -d 50 $$$$ &


### PR DESCRIPTION
',' is no longer supported in accre's current slurm. We need to use '|' instead. 