### PR TITLE
Fix memory setting for updated slurm

### DIFF
--- a/job_template.txt
+++ b/job_template.txt
@@ -5,7 +5,7 @@
 #SBATCH --nodes=1
 #SBATCH --ntasks=${job_ppn}
 #SBATCH --time=${job_walltime}
-#SBATCH --mem=${job_memory}mb
+#SBATCH --mem=${job_memory}
 #SBATCH -o ${job_output_file}
 
 echo "Starting smemwatch"

--- a/job_template_v3.txt
+++ b/job_template_v3.txt
@@ -5,7 +5,7 @@
 #SBATCH --nodes=1
 #SBATCH --ntasks=${job_ppn}
 #SBATCH --time=${job_walltime}
-#SBATCH --mem=${job_memory}mb
+#SBATCH --mem=${job_memory}
 #SBATCH -o ${job_output_file}
 
 echo "Starting smemwatch"


### PR DESCRIPTION
This just removes the "mb" specification from the template which was causing issue with recent slurm updates.
We should include the units in the value itself. Also, SLURM defaults to "mb" if none is specified. 